### PR TITLE
fix(report): replace employee application page 23

### DIFF
--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
@@ -3498,26 +3498,40 @@
             </span>
             <span>อยู่บ้านเลขที่</span>
             <span class="pdpa-saraburi-field-line pdpa-saraburi-address-part employee-data">
-                {{user?.currentAddress}}
+                {{currentAddressParts.houseNumber}}
             </span>
         </div>
         <div class="pdpa-saraburi-field-row">
             <span>หมู่ที่</span>
-            <span class="pdpa-saraburi-field-line pdpa-saraburi-small-part">&nbsp;</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-small-part employee-data">
+                {{currentAddressParts.moo}}
+            </span>
             <span>ซอย</span>
-            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{currentAddressParts.soi}}
+            </span>
             <span>ถนน</span>
-            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{currentAddressParts.road}}
+            </span>
             <span>ตำบล/แขวง</span>
-            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{currentAddressParts.subDistrict}}
+            </span>
         </div>
         <div class="pdpa-saraburi-field-row">
             <span>อำเภอ/เขต</span>
-            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{currentAddressParts.district}}
+            </span>
             <span>จังหวัด</span>
-            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{currentAddressParts.province}}
+            </span>
             <span>ไปรษณีย์</span>
-            <span class="pdpa-saraburi-field-line pdpa-saraburi-postcode-part">&nbsp;</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-postcode-part employee-data">
+                {{currentAddressParts.postalCode}}
+            </span>
         </div>
         <div class="pdpa-saraburi-field-row">
             <span>โทรศัพท์</span>

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
@@ -3451,110 +3451,133 @@
         </div>
     </div>
 </div>
-<div class="container-fluid page-break">
-    <div class="mt-3 pt-4 report-top">
-        <div class="d-flex justify-content-center">
-            <div class="mt-5">
-                <span class="attachment-title-sm">หนังสือยินยอมในการเข้าตรวจดูข้อมูลข่าวสารส่วนบุคคล</span>
-            </div>
+<div class="container-fluid page-break pdpa-saraburi-page">
+    <div class="pdpa-saraburi-title">
+        หนังสือยินยอมในการเข้าตรวจดูข้อมูลข่าวสารส่วนบุคคล
+    </div>
+
+    <div class="pdpa-saraburi-header">
+        <div class="pdpa-saraburi-field-row">
+            <span>ทำที่</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{companyReportHeader.FullName}}
+            </span>
+        </div>
+        <div class="pdpa-saraburi-field-row pdpa-saraburi-date-row">
+            <span>วันที่</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-date-part employee-data">
+                {{toDayOfMonth(currentDate)}}
+            </span>
+            <span>เดือน</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-month-part employee-data">
+                {{toThaiMonth(currentDate)}}
+            </span>
+            <span>พ.ศ.</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-year-part employee-data">
+                {{toThaiYear(currentDate)}}
+            </span>
         </div>
     </div>
-    <div class="mt-3">
-        <div class="report-header-pdpa-container">
-            <div class="d-flex flex-column report-header-pdpa">
-                <div>
-                    <div class="d-flex">
-                        <div><span class="pdpa-head-label">ทำที่</span></div>
-                        <div class="ml-2 mt-0 blank-dotted-bottom mw-400"><span
-                                class="employee-data">บจก.รักษาความปลอดภัย จีเซฟ</span></div>
-                    </div>
-                </div>
-                <div class="mt-2">
-                    <div class="d-flex">
-                        <div><span class="pdpa-head-label">วันที่</span></div>
-                        <div class="ml-2 mt-0 blank-dotted-bottom mw-400"><span
-                                class="employee-data">{{convertToDateString(currentDate)}}</span></div>
-                    </div>
-                </div>
-            </div>
+
+    <div class="pdpa-saraburi-personal-details">
+        <div class="pdpa-saraburi-field-row">
+            <span>ข้าพเจ้า(นาย/นาง/น.ส.)</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{signatureName(user)}}
+            </span>
+            <span>อายุ</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-age-part employee-data">
+                {{user?.birthdate ? age : ''}}
+            </span>
+            <span>ปี</span>
+        </div>
+        <div class="pdpa-saraburi-field-row">
+            <span>เลขบัตรประชาชน</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-id-part employee-data">
+                {{user?.idCardNumber}}
+            </span>
+            <span>อยู่บ้านเลขที่</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-address-part employee-data">
+                {{user?.currentAddress}}
+            </span>
+        </div>
+        <div class="pdpa-saraburi-field-row">
+            <span>หมู่ที่</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-small-part">&nbsp;</span>
+            <span>ซอย</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span>ถนน</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span>ตำบล/แขวง</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+        </div>
+        <div class="pdpa-saraburi-field-row">
+            <span>อำเภอ/เขต</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span>จังหวัด</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow">&nbsp;</span>
+            <span>ไปรษณีย์</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-postcode-part">&nbsp;</span>
+        </div>
+        <div class="pdpa-saraburi-field-row">
+            <span>โทรศัพท์</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-phone-part employee-data">
+                {{user?.phoneNo}}
+            </span>
+            <span>สังกัดบริษัท(ถ้ามี)</span>
+            <span class="pdpa-saraburi-field-line pdpa-saraburi-grow employee-data">
+                {{companyReportHeader.FullName}}
+            </span>
         </div>
     </div>
-    <div class="mt-5">
-        <div class="d-flex flex-column">
-            <div>เรียน นายทะเบียนกลาง/นายทะเบียนประจำกรุงเทพมหานคร</div>
-            <div class="mt-4">
-                <p class="attachment-paragraph lh mt-3">&#9634; ข้าพเจ้า ( <ng-container
-                        *ngIf="user?.title === 'นาย'; else elseFemale">
-                        <u>นาย</u>/นาง/น.ส
-                    </ng-container>
-                    <ng-template #elseFemale>
-                        <ng-container *ngIf="user?.title === 'นาง'; else  elseFemale2">
-                            นาย/<u>นาง</u>/น.ส
-                        </ng-container>
-                    </ng-template>
-                    <ng-template #elseFemale2>
-                        นาย/นาง/<u>น.ส.</u>
-                    </ng-template>) <span class="employee-data blank-dotted-bottom px25px">{{user?.firstName}}
-                        {{user?.lastName}}</span> เลขบัตรประจำตัวประชาชน <span
-                        class="employee-data blank-dotted-bottom px25px">{{user?.idCardNumber}}</span><br />
-                    <span>อยู่บ้านเลขที่</span><span
-                        class="blank-dotted-bottom text-center px-2 mw-200 employee-data">{{user?.currentAddress}}</span><br />
-                    <span>โทรศัพท์</span><span
-                        class="blank-dotted-bottom text-center px-2 mw-200 employee-data">{{user?.phoneNo}}</span>
-                    <span>สังกัดบริษัทรักษาความปลอดภัย (ถ้ามี)</span><span
-                        class="blank-dotted-bottom text-center px-2 mw-200 employee-data">บจก.รักษาความปลอดภัย จีเซฟ</span>
-                </p>
-                <p class="attachment-paragraph lh mt-3">&#9634; ข้าพเจ้า บริษัทรักษาความปลอดภัย <span
-                        class="employee-data blank-dotted-bottom mw-200 inline">&nbsp;</span>
-                    โดยมี (นาย/นาง/น.ส.) <span class="employee-data blank-dotted-bottom mw-260 inline">&nbsp;</span><br /><span>เป็นกรรมการผู้มีอำนาจ อยู่บ้านเลขที่</span><span class="employee-data blank-dotted-bottom mw-400 inline"></span>
-                    <span>โทรศัพท์</span><span class="employee-data blank-dotted-bottom mw-200 inline">&nbsp;</span><br />
-                    <span>โดยหนังสือฉบับนี้</span>
-                </p>
-                <p class="attachment-paragraph lh mt-3">
-                    ๑. ข้าพเจ้ายินยอมให้ งานธุรกิจรักษาความปลอดภัย กองบังคับการอำนวยการ กองบัญชาการตำรวจนครบาล ซึ่งเป็นหน่วยงานของรัฐ
-                    ตั้งอยู่ที่ ๓๒๓ กองบัญชาการตำรวจนครบาล ถนนศรีอยุธยา แขวงดุสิต เขตดุสิต กรุงเทพมหานคร
-                    ซึ่งเป็นหน่วยงานที่ข้าพเจ้าอนุญาตให้ดำเนินการใดๆ ในการตรวจประวัติ
-                    ข้อมูลของข้าพเจ้าที่เกี่ยวข้องในการพิจารณาออกใบอนุญาตในงานธุรกิจรักษาความปลอดภัย
-                    หรือข้อมูลอื่นซึ่งจำเป็นเพื่อปฏิบัติตามอำนาจหน้าที่และกฎหมายที่เกี่ยวข้อง โดยไม่มีเงื่อนไขใดๆ
-                    ทั้งสิ้น
-                </p>
-                <p class="attachment-paragraph lh mt-3">
-                    ๒. ข้าพเจ้ายินยอมให้ งานธุรกิจรักษาความปลอดภัย กองบังคับการอำนวยการ กองบัญชาการตำรวจนครบาล ดำเนินการจัดเก็บข้อมูล
-                    ประวัติส่วนบุคคลรวมทั้งเปิดเผยข้อมูลของข้าพเจ้าแก่หน่วยงานของรัฐ
-                    เพื่อปฏิบัติตามอำนาจหน้าที่และกฎหมายที่เกี่ยวข้อง
-                </p>
-                <p class="attachment-paragraph lh mt-3">
-                    ข้าพเจ้าได้อ่านและเข้าใจข้อความในหนังสือยินยอมฉบับนี้โดยตลอดแล้ว จึงได้ลงลายมือชื่อไว้เป็นหลักฐาน ณ
-                    วัน เดือน ปี ที่ ระบุข้างต้น
-                </p>
-                <p class="attachment-paragraph lh mt-3">
-                    ข้าพเจ้าขอรับรองว่า ข้อความในเอกสารคำขอและเอกสารหลักฐานประกอบคำขอเป็นความจริงทุกประการ
-                </p>
+
+    <div class="pdpa-saraburi-intro">โดยหนังสือฉบับนี้</div>
+
+    <div class="pdpa-saraburi-body">
+        <p>
+            1. ข้าพเจ้ายินยอมให้ คณะทำงานขับเคลื่อนการบังคับใช้กฎหมายว่าด้วยธุรกิจรักษาความปลอดภัย
+            ตำรวจภูธรจังหวัดสระบุรี ซึ่งเป็นหน่วยงานของรัฐ ตั้งอยู่ที่ 54 หมู่ 5 ตำบลทับกวาง
+            อำเภอแก่งคอย จังหวัดสระบุรี ซึ่งเป็นหน่วยงานที่ข้าพเจ้าอนุญาตให้ดำเนินการใดๆ
+            ในการตรวจประวัติข้อมูลของข้าพเจ้าที่เกี่ยวข้องในการพิจารณาออกใบอนุญาตในงานธุรกิจรักษาความปลอดภัย
+            หรือข้อมูลอื่นซึ่งจำเป็นเพื่อปฏิบัติตามอำนาจหน้าที่และกฎหมายที่เกี่ยวข้อง โดยไม่มีเงื่อนไขใดๆ ทั้งสิ้น
+        </p>
+        <p>
+            2. ข้าพเจ้ายินยอมให้ คณะทำงานขับเคลื่อนการบังคับใช้กฎหมายว่าด้วยธุรกิจรักษาความปลอดภัย
+            ตำรวจภูธรจังหวัดสระบุรี ดำเนินการจัดเก็บข้อมูล ประวัติส่วนบุคคล รวมทั้งเปิดเผยข้อมูลของข้าพเจ้า
+            แก่หน่วยงานของรัฐ เพื่อปฏิบัติตามอำนาจหน้าที่และกฎหมายที่เกี่ยวข้อง
+        </p>
+    </div>
+
+    <div class="pdpa-saraburi-declarations">
+        <p>
+            ข้าพเจ้าได้อ่านและเข้าใจข้อความในหนังสือยินยอมฉบับนี้โดยตลอดแล้ว
+            จึงได้ลงลายมือชื่อไว้เป็นหลักฐาน ณ วัน เดือน ปี ที่ระบุไว้ข้างต้น
+        </p>
+        <p>
+            ข้าพเจ้าขอรับรองว่า ข้อความในเอกสารคำขอและเอกสารหลักฐานประกอบคำขอเป็นความจริงทุกประการ
+        </p>
+    </div>
+
+    <div class="pdpa-saraburi-footer">
+        <div class="pdpa-saraburi-signature">
+            <div class="pdpa-saraburi-signature-row">
+                <span>(ลงชื่อ)</span>
+                <span class="pdpa-saraburi-field-line pdpa-saraburi-signature-line">&nbsp;</span>
+                <span>ผู้ให้ความยินยอม</span>
+            </div>
+            <div class="pdpa-saraburi-signature-row pdpa-saraburi-printed-name-row">
+                <span>(</span>
+                <span class="pdpa-saraburi-field-line pdpa-saraburi-signature-line employee-data">
+                    {{signatureName(user)}}
+                </span>
+                <span>)</span>
+                <span class="pdpa-saraburi-printed-name-label">ตัวบรรจง</span>
             </div>
         </div>
-        <div class="mt-5 pt-5 pdpa-signature-container">
-            <div class="d-flex pdpa-signature">
-                <div class="ml-auto">
-                    <div class="d-flex align-items-end">
-                        <div>ลงชื่อ</div>
-                        <div class="blank-dotted-bottom text-input ml-2 mw-200"></div>
-                        <div class="ml-2">
-                            <span class="pdpa-signature-position">ผู้ให้ความยินยอม/ผู้รับรอง</span>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-end">
-                        <div [class.ml-3]="checkIsLongName(user)" [class.ml-5]="!checkIsLongName(user)">(</div>
-                        <div>
-                            <span
-                                class="employee-data blank-dotted-bottom signature-bracket">{{signatureName(user)}}</span>
-                        </div>
-                        <div>)</div>
-                    </div>
-                </div>
-            </div>
-            <div class="pdpa-warning">
-                <u>คำเตือน</u> ผู้ใดแจ้งความอันเป็นเท็จแก่เจ้าพนักงาน มีความผิดตามกฎหมายอาญา มาตรา ๑๓๗ มาตรา ๒๖๗ และมาตรา ๒๖๘
-            </div>
+
+        <div class="pdpa-saraburi-warning">
+            <u>คำเตือน</u> ผู้ใดแจ้งความอันเป็นเท็จแก่เจ้าพนักงาน มีความผิดตามกฎหมายอาญา
+            มาตรา 137 มาตรา 267 และมาตรา 268
         </div>
     </div>
 </div>

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
@@ -532,6 +532,163 @@ ul.dashed>li:before {
     left: 0;
 }
 
+.pdpa-saraburi-page {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    min-height: 297mm;
+    padding: 16mm 15mm 12mm;
+    width: 210mm;
+}
+
+.pdpa-saraburi-title {
+    font-size: 22px;
+    font-weight: 900;
+    margin-top: 8px;
+    text-align: center;
+}
+
+.pdpa-saraburi-header {
+    margin-left: auto;
+    margin-top: 34px;
+    width: 56%;
+}
+
+.pdpa-saraburi-field-row {
+    align-items: flex-end;
+    display: flex;
+    min-height: 32px;
+    white-space: nowrap;
+}
+
+.pdpa-saraburi-field-row > * + * {
+    margin-left: 6px;
+}
+
+.pdpa-saraburi-field-line {
+    align-items: flex-end;
+    border-bottom: 2px dotted #000000;
+    box-sizing: border-box;
+    display: inline-flex;
+    justify-content: center;
+    line-height: 1.2;
+    min-height: 28px;
+    overflow-wrap: break-word;
+    padding: 0 5px 2px;
+    text-align: center;
+    white-space: normal;
+    word-break: break-word;
+}
+
+.pdpa-saraburi-grow,
+.pdpa-saraburi-address-part {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.pdpa-saraburi-date-row {
+    margin-top: 4px;
+}
+
+.pdpa-saraburi-date-part {
+    width: 54px;
+}
+
+.pdpa-saraburi-month-part {
+    width: 112px;
+}
+
+.pdpa-saraburi-year-part {
+    width: 72px;
+}
+
+.pdpa-saraburi-personal-details {
+    margin-top: 34px;
+}
+
+.pdpa-saraburi-personal-details .pdpa-saraburi-field-row + .pdpa-saraburi-field-row {
+    margin-top: 2px;
+}
+
+.pdpa-saraburi-age-part,
+.pdpa-saraburi-small-part {
+    width: 58px;
+}
+
+.pdpa-saraburi-id-part {
+    flex: 0 0 180px;
+}
+
+.pdpa-saraburi-address-part {
+    min-width: 180px;
+}
+
+.pdpa-saraburi-postcode-part {
+    width: 100px;
+}
+
+.pdpa-saraburi-phone-part {
+    flex: 0 0 210px;
+}
+
+.pdpa-saraburi-intro {
+    margin-top: 26px;
+}
+
+.pdpa-saraburi-body {
+    margin-top: 24px;
+}
+
+.pdpa-saraburi-body p,
+.pdpa-saraburi-declarations p {
+    line-height: 1.65;
+    margin-bottom: 14px;
+    text-align: justify;
+    text-indent: 72px;
+}
+
+.pdpa-saraburi-declarations {
+    margin-top: 4px;
+}
+
+.pdpa-saraburi-footer {
+    margin-top: auto;
+}
+
+.pdpa-saraburi-signature {
+    margin-left: auto;
+    width: 55%;
+}
+
+.pdpa-saraburi-signature-row {
+    align-items: flex-end;
+    display: flex;
+    justify-content: flex-start;
+    white-space: nowrap;
+}
+
+.pdpa-saraburi-signature-row > * + * {
+    margin-left: 7px;
+}
+
+.pdpa-saraburi-printed-name-row {
+    margin-left: 55px;
+    margin-top: 5px;
+}
+
+.pdpa-saraburi-signature-line {
+    flex: 0 0 225px;
+}
+
+.pdpa-saraburi-printed-name-label {
+    margin-left: 2px;
+}
+
+.pdpa-saraburi-warning {
+    line-height: 1.65;
+    margin-top: 38px;
+}
+
 .col-subject-lesson {
     width: 190px;
 }

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.ts
@@ -6,6 +6,7 @@ import { ApplicationStateService } from 'src/app/core/services/application-state
 import { UserService } from 'src/app/core/services/user.service';
 import { JobHistory, LanguageAbility, User } from 'src/app/core/models/user';
 import { environment } from 'src/environments/environment';
+import { parseThaiAddress, ThaiAddressParts } from './thai-address.parser';
 
 @Component({
   selector: 'app-employee-aplication-form',
@@ -19,6 +20,7 @@ export class EmployeeAplicationFormComponent implements OnDestroy, OnInit {
   empNoString = '';
   birthDateString: string;
   age: number;
+  currentAddressParts: ThaiAddressParts = parseThaiAddress('');
   currentDate = new Date();
   companyReportHeader = {
     FullName: environment.companyFullName,
@@ -81,6 +83,7 @@ export class EmployeeAplicationFormComponent implements OnDestroy, OnInit {
       this.spinner.showLoadingSpinner();
       this.userService.getUser(this.empNo).subscribe(user => {
         this.user = user;
+        this.currentAddressParts = parseThaiAddress(this.user.currentAddress);
         this.age = this.convertToAge(new Date(this.user.birthdate));
         this.spinner.hideLoadingSpinner(0);
       }, error => {

--- a/src/app/modules/employee/pages/report/employee-aplication-form/thai-address.parser.spec.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/thai-address.parser.spec.ts
@@ -1,0 +1,93 @@
+import { parseThaiAddress, ThaiAddressParts } from './thai-address.parser';
+
+describe('parseThaiAddress', () => {
+  it('extracts the employee address used by the Saraburi consent form', () => {
+    expect(parseThaiAddress(
+      '59/10 หมู่ที่ 12 ต.กะมัง อ.พระนครศรีอยุธยา ' +
+      'จ.พระนครศรีอยุธยา 13000'
+    )).toEqual({
+      houseNumber: '59/10',
+      moo: '12',
+      soi: '',
+      road: '',
+      subDistrict: 'กะมัง',
+      district: 'พระนครศรีอยุธยา',
+      province: 'พระนครศรีอยุธยา',
+      postalCode: '13000'
+    } as ThaiAddressParts);
+  });
+
+  it('supports Bangkok labels and multi-word soi and road values', () => {
+    expect(parseThaiAddress(
+      '88, ซอย รัชดาภิเษก 18 ถนน สุทธิสารวินิจฉัย ' +
+      'แขวง สามเสนนอก เขต ห้วยขวาง กทม. 10310'
+    )).toEqual({
+      houseNumber: '88',
+      moo: '',
+      soi: 'รัชดาภิเษก 18',
+      road: 'สุทธิสารวินิจฉัย',
+      subDistrict: 'สามเสนนอก',
+      district: 'ห้วยขวาง',
+      province: 'กรุงเทพมหานคร',
+      postalCode: '10310'
+    } as ThaiAddressParts);
+  });
+
+  it('does not treat a village name as a Moo marker', () => {
+    expect(parseThaiAddress(
+      '99 หมู่บ้านสุขใจ แขวงบางนา เขตบางนา ' +
+      'กรุงเทพมหานคร 10260'
+    )).toEqual({
+      houseNumber: '99 หมู่บ้านสุขใจ',
+      moo: '',
+      soi: '',
+      road: '',
+      subDistrict: 'บางนา',
+      district: 'บางนา',
+      province: 'กรุงเทพมหานคร',
+      postalCode: '10260'
+    } as ThaiAddressParts);
+  });
+
+  it('supports abbreviated labels when optional fields are absent', () => {
+    expect(parseThaiAddress(
+      '211/41 ถ.สุดบรรทัด ต.ปากเพรียว ' +
+      'อ.เมืองสระบุรี จ.สระบุรี 18000'
+    )).toEqual({
+      houseNumber: '211/41',
+      moo: '',
+      soi: '',
+      road: 'สุดบรรทัด',
+      subDistrict: 'ปากเพรียว',
+      district: 'เมืองสระบุรี',
+      province: 'สระบุรี',
+      postalCode: '18000'
+    } as ThaiAddressParts);
+  });
+
+  it('returns blank fields for an empty address', () => {
+    expect(parseThaiAddress('')).toEqual({
+      houseNumber: '',
+      moo: '',
+      soi: '',
+      road: '',
+      subDistrict: '',
+      district: '',
+      province: '',
+      postalCode: ''
+    } as ThaiAddressParts);
+  });
+
+  it('preserves unrecognized text in the house-number field', () => {
+    expect(parseThaiAddress('อาคารเอ ชั้น 2 10110')).toEqual({
+      houseNumber: 'อาคารเอ ชั้น 2',
+      moo: '',
+      soi: '',
+      road: '',
+      subDistrict: '',
+      district: '',
+      province: '',
+      postalCode: '10110'
+    } as ThaiAddressParts);
+  });
+});

--- a/src/app/modules/employee/pages/report/employee-aplication-form/thai-address.parser.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/thai-address.parser.ts
@@ -1,0 +1,106 @@
+export interface ThaiAddressParts {
+  houseNumber: string;
+  moo: string;
+  soi: string;
+  road: string;
+  subDistrict: string;
+  district: string;
+  province: string;
+  postalCode: string;
+}
+
+export function parseThaiAddress(value: string): ThaiAddressParts {
+  const result: ThaiAddressParts = {
+    houseNumber: '',
+    moo: '',
+    soi: '',
+    road: '',
+    subDistrict: '',
+    district: '',
+    province: '',
+    postalCode: ''
+  };
+
+  let address = (value || '')
+    .replace(/,/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!address) {
+    return result;
+  }
+
+  const postalCodeMatch = address.match(/(?:^|\s)(\d{5})$/);
+  if (postalCodeMatch) {
+    result.postalCode = postalCodeMatch[1];
+    address = address.substring(0, postalCodeMatch.index).trim();
+  }
+
+  const markerPattern = new RegExp(
+    '(^|\\s)' +
+    '(กรุงเทพมหานคร|กทม\\.?|หมู่ที่|หมู่(?=\\s|[0-9๐-๙])|' +
+    'ม\\.|ซอย|ซ\\.|ถนน|ถ\\.|' +
+    'ตำบล|ต\\.|แขวง|อำเภอ|อ\\.|เขต|จังหวัด|จ\\.)\\s*',
+    'g'
+  );
+  const markers: Array<{ marker: string; start: number; valueStart: number }> = [];
+  let markerMatch: RegExpExecArray;
+
+  while ((markerMatch = markerPattern.exec(address)) !== null) {
+    markers.push({
+      marker: markerMatch[2],
+      start: markerMatch.index,
+      valueStart: markerPattern.lastIndex
+    });
+  }
+
+  if (markers.length === 0) {
+    result.houseNumber = address;
+    return result;
+  }
+
+  result.houseNumber = address.substring(0, markers[0].start).trim();
+
+  markers.forEach((match, index) => {
+    const nextMarker = markers[index + 1];
+    const valueEnd = nextMarker ? nextMarker.start : address.length;
+    const segmentValue = address.substring(match.valueStart, valueEnd).trim();
+
+    switch (match.marker) {
+      case 'หมู่ที่':
+      case 'หมู่':
+      case 'ม.':
+        result.moo = segmentValue;
+        break;
+      case 'ซอย':
+      case 'ซ.':
+        result.soi = segmentValue;
+        break;
+      case 'ถนน':
+      case 'ถ.':
+        result.road = segmentValue;
+        break;
+      case 'ตำบล':
+      case 'ต.':
+      case 'แขวง':
+        result.subDistrict = segmentValue;
+        break;
+      case 'อำเภอ':
+      case 'อ.':
+      case 'เขต':
+        result.district = segmentValue;
+        break;
+      case 'กรุงเทพมหานคร':
+      case 'กทม':
+      case 'กทม.':
+        result.province = 'กรุงเทพมหานคร';
+        break;
+      case 'จังหวัด':
+      case 'จ.':
+        result.province = segmentValue;
+        break;
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Replace employee application form page 23 with the Saraburi personal-information consent form.
- Preserve employee, date, and company autofill bindings plus the intentional following blank page.
- Parse the legacy single-line Thai address into house number, Moo, Soi, road, Tambon,
  Amphoe, province, and postal-code fields without changing stored employee data.
- Add scoped A4 print styles compatible with the repository's Electron 5 runtime.

## Testing

- [x] Production Angular build with Intel Node 12.22.12 (`ng build --base-href ./ --prod`)
- [x] Six focused Thai-address parser specs pass
- [x] Electron 5 `printToPDF` visual verification; address parts render in their
  official fields, page count remains 31, page 24 stays blank, and page 25 starts the next form
- [ ] `npm test -- --watch=false --browsers=ChromeHeadless` — the branch reports
  28 existing unrelated failures and 7 successes (including all six new parser specs)
- [ ] `npm run lint` — baseline and branch both fail on existing repository-wide lint debt

## Risk / Rollback

- Risk is limited to print-only HTML, scoped CSS, and frontend-only parsing for this report page.
- Roll back by reverting this PR.
