### PR TITLE
feat(report): add power-of-attorney page

### DIFF
--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
@@ -4243,3 +4243,148 @@
         </div>
     </div>
 </div>
+<div class="container-fluid page-break power-of-attorney-page" data-testid="power-of-attorney-page">
+  <header class="power-of-attorney-header">
+    <h1 class="power-of-attorney-title">หนังสือมอบอำนาจ</h1>
+    <div class="power-of-attorney-meta">
+      <div class="power-of-attorney-field-row">
+        <span>เขียนที่</span>
+        <span class="power-of-attorney-field-line power-of-attorney-grow employee-data">
+          บริษัท รักษาความปลอดภัย จีเซฟ จำกัด
+        </span>
+      </div>
+      <div class="power-of-attorney-field-row power-of-attorney-date-row">
+        <span>วันที่</span>
+        <span class="power-of-attorney-field-line power-of-attorney-day employee-data">
+          {{currentDate.getDate()}}
+        </span>
+        <span>เดือน</span>
+        <span class="power-of-attorney-field-line power-of-attorney-month employee-data">
+          {{thaiMonth[currentDate.getMonth()]}}
+        </span>
+        <span>พ.ศ.</span>
+        <span class="power-of-attorney-field-line power-of-attorney-year employee-data">
+          {{currentDate.getFullYear() + 543}}
+        </span>
+      </div>
+    </div>
+  </header>
+
+  <section class="power-of-attorney-grantor">
+    <div class="power-of-attorney-field-row">
+      <span>ข้าพเจ้า</span>
+      <span class="power-of-attorney-field-line power-of-attorney-grow employee-data">
+        {{signatureName(user)}}
+      </span>
+      <span>บัตรประชาชน</span>
+      <span class="power-of-attorney-field-line power-of-attorney-id employee-data">
+        {{user?.idCardNumber}}
+      </span>
+    </div>
+    <div class="power-of-attorney-field-row">
+      <span>อยู่บ้านเลขที่</span>
+      <span class="power-of-attorney-field-line power-of-attorney-house employee-data">
+        {{currentAddressParts.houseNumber}}
+      </span>
+      <span>หมู่</span>
+      <span class="power-of-attorney-field-line power-of-attorney-moo employee-data">
+        {{currentAddressParts.moo}}
+      </span>
+      <span>ตรอก/ซอย</span>
+      <span class="power-of-attorney-field-line power-of-attorney-grow employee-data">
+        {{currentAddressParts.soi}}
+      </span>
+      <span>ถนน</span>
+      <span class="power-of-attorney-field-line power-of-attorney-road employee-data">
+        {{currentAddressParts.road}}
+      </span>
+    </div>
+    <div class="power-of-attorney-field-row">
+      <span>ตำบล/แขวง</span>
+      <span class="power-of-attorney-field-line power-of-attorney-grow employee-data">
+        {{currentAddressParts.subDistrict}}
+      </span>
+      <span>อำเภอ/เขต</span>
+      <span class="power-of-attorney-field-line power-of-attorney-grow employee-data">
+        {{currentAddressParts.district}}
+      </span>
+      <span>จังหวัด</span>
+      <span class="power-of-attorney-field-line power-of-attorney-grow employee-data">
+        {{currentAddressParts.province}}
+      </span>
+    </div>
+    <div class="power-of-attorney-field-row">
+      <span>ไปรษณีย์</span>
+      <span class="power-of-attorney-field-line power-of-attorney-postal-code employee-data">
+        {{currentAddressParts.postalCode}}
+      </span>
+      <span>เบอร์โทร</span>
+      <span class="power-of-attorney-field-line power-of-attorney-phone employee-data">
+        {{user?.phoneNo}}
+      </span>
+    </div>
+  </section>
+
+  <section class="power-of-attorney-body">
+    <p>
+      ขอมอบอำนาจให้
+      <span class="employee-data">นายสิรภพ บุญศรี</span>
+      บัตรประชาชน
+      <span class="employee-data">1103702684066</span>
+      อยู่บ้านเลขที่
+      <span class="employee-data">52</span>
+      ซอยเสนานิคม 1 ซอย 40 แยก 8 ถนนเสนานิคม 1 แขวงลาดพร้าว เขตลาดพร้าว กรุงเทพมหานคร 10230
+      เบอร์โทร
+      <span class="employee-data">099-7569360</span>
+      เป็นผู้ดำเนินการ ยื่นใบอนุญาตเป็นพนักงานรักษาความปลอดภัยรับอนุญาต แทนข้าพเจ้า
+    </p>
+    <p>
+      การใดที่ผู้รับมอบอำนาจได้กระทำภายใต้ขอบเขตแห่งการมอบอำนาจนี้
+      ข้าพเจ้าขอรับผิดชอบและมีผลผูกพันข้าพเจ้าทุกประการ
+    </p>
+    <p>
+      หนังสือมอบอำนาจฉบับนี้เป็นการมอบอำนาจให้ดำเนินการตามที่ระบุไว้ข้างต้น
+    </p>
+  </section>
+
+  <footer class="power-of-attorney-footer">
+    <div class="power-of-attorney-attachments">
+      <div>เอกสารประกอบหนังสือมอบอำนาจ</div>
+      <div class="power-of-attorney-attachment-item">
+        - สำเนาบัตรประชาชนผู้มอบอำนาจและผู้รับมอบอำนาจ
+      </div>
+    </div>
+    <div class="power-of-attorney-signatures">
+      <div class="power-of-attorney-signature-block">
+        <div class="power-of-attorney-signature-row">
+          <span>ลงชื่อ</span>
+          <span class="power-of-attorney-field-line power-of-attorney-signature-line">&nbsp;</span>
+          <span>ผู้มอบอำนาจ</span>
+        </div>
+        <div class="power-of-attorney-printed-name">
+          (<span class="employee-data">{{signatureName(user)}}</span>)
+        </div>
+      </div>
+      <div class="power-of-attorney-signature-block">
+        <div class="power-of-attorney-signature-row">
+          <span>ลงชื่อ</span>
+          <span class="power-of-attorney-field-line power-of-attorney-signature-line">&nbsp;</span>
+          <span>ผู้รับมอบอำนาจ</span>
+        </div>
+        <div class="power-of-attorney-printed-name">
+          (<span class="employee-data">นายสิรภพ บุญศรี</span>)
+        </div>
+      </div>
+      <div class="power-of-attorney-signature-block">
+        <div class="power-of-attorney-signature-row">
+          <span>ลงชื่อ</span>
+          <span class="power-of-attorney-field-line power-of-attorney-signature-line">&nbsp;</span>
+          <span>พยาน</span>
+        </div>
+        <div class="power-of-attorney-printed-name">
+          (<span class="employee-data">นายกฤษฎา วาฬกิจจานนท์</span>)
+        </div>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
@@ -827,3 +827,170 @@ ul.dashed>li:before {
     width: 100%;
     height: 100%;
 }
+
+.power-of-attorney-page {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  min-height: 297mm;
+  padding: 16mm 15mm 12mm;
+  width: 210mm;
+}
+
+.power-of-attorney-header {
+  min-height: 210px;
+  padding-top: 12px;
+}
+
+.power-of-attorney-title {
+  font-size: 24px;
+  font-weight: 500;
+  margin: 0;
+  text-align: center;
+}
+
+.power-of-attorney-meta {
+  margin-left: auto;
+  margin-top: 48px;
+  width: 56%;
+}
+
+.power-of-attorney-field-row {
+  align-items: flex-end;
+  display: flex;
+  min-height: 32px;
+  white-space: nowrap;
+}
+
+.power-of-attorney-field-row + .power-of-attorney-field-row {
+  margin-top: 5px;
+}
+
+.power-of-attorney-field-row > * + * {
+  margin-left: 6px;
+}
+
+.power-of-attorney-field-line {
+  align-items: flex-end;
+  border-bottom: 2px dotted #000000;
+  box-sizing: border-box;
+  display: inline-flex;
+  justify-content: center;
+  line-height: 1.2;
+  min-height: 28px;
+  overflow-wrap: break-word;
+  padding: 0 5px 2px;
+  text-align: center;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.power-of-attorney-grow {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.power-of-attorney-date-row {
+  margin-top: 8px;
+}
+
+.power-of-attorney-day {
+  width: 52px;
+}
+
+.power-of-attorney-month {
+  width: 112px;
+}
+
+.power-of-attorney-year {
+  width: 72px;
+}
+
+.power-of-attorney-grantor {
+  margin-top: 34px;
+}
+
+.power-of-attorney-id {
+  flex: 0 0 190px;
+}
+
+.power-of-attorney-house {
+  flex: 0 0 82px;
+}
+
+.power-of-attorney-moo {
+  flex: 0 0 50px;
+}
+
+.power-of-attorney-road {
+  flex: 0 0 125px;
+}
+
+.power-of-attorney-postal-code {
+  flex: 0 0 110px;
+}
+
+.power-of-attorney-phone {
+  flex: 0 0 210px;
+}
+
+.power-of-attorney-body {
+  margin-top: 38px;
+}
+
+.power-of-attorney-body p {
+  line-height: 1.75;
+  margin: 0 0 16px;
+  text-align: justify;
+  text-indent: 72px;
+}
+
+.power-of-attorney-footer {
+  align-items: flex-end;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 150px;
+}
+
+.power-of-attorney-attachments {
+  font-size: 14px;
+  line-height: 1.8;
+  padding-bottom: 12px;
+  width: 48%;
+}
+
+.power-of-attorney-attachment-item {
+  font-size: 14px;
+  margin-left: 18px;
+}
+
+.power-of-attorney-signatures {
+  padding-bottom: 10px;
+  width: 50%;
+}
+
+.power-of-attorney-signature-block + .power-of-attorney-signature-block {
+  margin-top: 36px;
+}
+
+.power-of-attorney-signature-row {
+  align-items: flex-end;
+  display: flex;
+  white-space: nowrap;
+}
+
+.power-of-attorney-signature-row > * + * {
+  margin-left: 7px;
+}
+
+.power-of-attorney-signature-line {
+  flex: 1 1 auto;
+  min-width: 175px;
+}
+
+.power-of-attorney-printed-name {
+  margin-left: 50px;
+  margin-top: 6px;
+  text-align: center;
+  width: 235px;
+}

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
@@ -1,0 +1,95 @@
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { ElectronService } from 'ngx-electron';
+import { of } from 'rxjs';
+import { SpinnerHelper } from 'src/app/core/helpers/spinner.helper';
+import { User } from 'src/app/core/models/user';
+import { ApplicationStateService } from 'src/app/core/services/application-state.service';
+import { UserService } from 'src/app/core/services/user.service';
+import { EmployeeAplicationFormComponent } from './employee-aplication-form.component';
+
+describe('EmployeeAplicationFormComponent', () => {
+  let fixture: ComponentFixture<EmployeeAplicationFormComponent>;
+  let component: EmployeeAplicationFormComponent;
+
+  const user = {
+    empNo: 1234,
+    company: { name: 'GSAFE' },
+    userPosition: { nameTH: 'พนักงานรักษาความปลอดภัย' },
+    site: { name: 'สำนักงานใหญ่' },
+    idCardNumber: '1909800608435',
+    title: 'นาย',
+    firstName: 'กิตติธร',
+    lastName: 'ธรรมพูนพิศัย',
+    imageProfile: null,
+    birthdate: '1966-07-26',
+    phoneNo: '0854621466',
+    currentAddress: '59/10 หมู่ที่ 12 ซอย ร่มเย็น ถนน พหลโยธิน ต.กะมัง ' +
+      'อ.พระนครศรีอยุธยา จ.พระนครศรีอยุธยา 13000',
+    languageAbilities: [],
+    jobHistories: []
+  } as User;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [EmployeeAplicationFormComponent],
+      providers: [
+        ApplicationStateService,
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ empNo: '1234' }) }
+        },
+        {
+          provide: ElectronService,
+          useValue: { isElectronApp: false }
+        },
+        {
+          provide: SpinnerHelper,
+          useValue: {
+            showLoadingSpinner: () => undefined,
+            hideLoadingSpinner: () => Promise.resolve()
+          }
+        },
+        {
+          provide: UserService,
+          useValue: { getUser: () => of(user) }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmployeeAplicationFormComponent);
+    component = fixture.componentInstance;
+    component.currentDate = new Date(2026, 6, 26);
+    fixture.detectChanges();
+  });
+
+  it('renders a final power-of-attorney page with employee and representative details', () => {
+    const page: HTMLElement = fixture.nativeElement.querySelector('[data-testid="power-of-attorney-page"]');
+
+    expect(page).not.toBeNull();
+    if (!page) {
+      return;
+    }
+    expect(page.textContent).toContain('หนังสือมอบอำนาจ');
+    expect(page.textContent).toContain('นายกิตติธร ธรรมพูนพิศัย');
+    expect(page.textContent).toContain('1909800608435');
+    expect(page.textContent).toContain('59/10');
+    expect(page.textContent).toContain('12');
+    expect(page.textContent).toContain('ร่มเย็น');
+    expect(page.textContent).toContain('พหลโยธิน');
+    expect(page.textContent).toContain('กะมัง');
+    expect(page.textContent).toContain('พระนครศรีอยุธยา');
+    expect(page.textContent).toContain('13000');
+    expect(page.textContent).toContain('0854621466');
+    expect(page.textContent).toContain('26');
+    expect(page.textContent).toContain('กรกฎาคม');
+    expect(page.textContent).toContain('2569');
+    expect(page.textContent).toContain('นายสิรภพ บุญศรี');
+    expect(page.textContent).toContain('1103702684066');
+    expect(page.textContent).toContain('099-7569360');
+    expect(page.textContent).toContain('นายกฤษฎา วาฬกิจจานนท์');
+    expect(page.querySelector('img')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- append a final Thai power-of-attorney page to employee application PDFs
- populate employee identity, contact, parsed address, representative, and witness details
- keep the new page image-free and add page-scoped A4 print styling

## Testing

- [x] Focused Karma specs: 7 passed
- [x] Targeted TSLint for the new component spec
- [x] Production Angular build with Intel Node 12
- [x] Electron PDF visual verification: 32 pages; page 31 unchanged; new page 32 fits on one A4 sheet
- [ ] Full Karma suite: 28 pre-existing failures, 8 passes (failure count unchanged from `master`; the new regression test adds one pass)
- [ ] Repository-wide lint: blocked by the existing TSLint backlog; the changed TypeScript spec passes targeted lint

## Risk and rollback

Print layout can vary with renderer and font versions; this was verified using the repository's Electron 5 and Intel Node 12 runtime. Roll back by reverting this PR.
