### PR TITLE
fix(report): keep application pages within print bounds

### DIFF
--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
@@ -3918,22 +3918,18 @@
             </div>
         </div>
     </div>
-    <div class="mt-2">
-        <div class="d-flex flex-column w-100 application-form-row">
-            <div>
-                <div class="d-flex flex-wrap align-items-end text-input-18">
-                    <div>ชื่อ-นามสกุล</div>
-                    <div class="ml-2 blank-dotted-bottom text-center mw-300"><span
-                            class="employee-data">{{user?.firstName}} {{user?.lastName}}</span></div>
-                    <div class="ml-2">หน่วยงาน</div>
-                    <div class="ml-2 blank-dotted-bottom text-center mw-350">
-                        <span class="employee-data">{{ user?.site?.name }}</span>
-                    </div>
-                    <div class="ml-2">วันที่</div>
-                    <div class="ml-2 blank-dotted-bottom text-center mw-100"><span
-                        class="employee-data">{{toThaiDateString(currentDate)}}</span></div>
-                </div>
-            </div>
+    <div class="equipment-request-meta application-form-row mt-2 text-input-18">
+        <div>ชื่อ-นามสกุล</div>
+        <div class="blank-dotted-bottom equipment-request-meta-value">
+            <span class="employee-data">{{user?.firstName}} {{user?.lastName}}</span>
+        </div>
+        <div>หน่วยงาน</div>
+        <div class="blank-dotted-bottom equipment-request-meta-value">
+            <span class="employee-data">{{ user?.site?.name }}</span>
+        </div>
+        <div>วันที่</div>
+        <div class="blank-dotted-bottom equipment-request-meta-value">
+            <span class="employee-data">{{toThaiDateString(currentDate)}}</span>
         </div>
     </div>
     <table class="table table-bordered equipment-table mt-3">
@@ -3977,7 +3973,7 @@
             ข้าพเจ้าได้ตรวจนับอุปกรณ์เป็นที่เรียบร้อยแล้ว และ ยินดีให้บริษัท รักษาความปลอดภัย จีเซฟ จำกัด หักเงินค่าอุปกรณ์ดังกล่าวของข้าพเจ้าจากเงินเดือน และ/หรือค่าจ้าง และ/หรือรายได้อื่นๆของข้าพเจ้า เพื่อเป็นค่าอุปกรณ์ที่ข้าพเจ้าจัดซื้อ ข้าพเจ้าได้อ่านข้อความทั้งหมดเข้าใจแล้วจึงลงลายมือชื่อไว้เป็นหลักฐาน
         </p>
     </div>
-    <div class="row justify-content-center px-3 py-0 mt-0">
+    <div class="row equipment-request-signatures justify-content-center px-3 py-0 mt-0">
         <div class="col-5 mr-2 p-0">
             <div class="p-3">
                 <div class="d-flex justify-content-center">

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
@@ -717,6 +717,43 @@ ul.dashed>li:before {
     font-size: 16px;
 }
 
+.equipment-request-meta {
+  align-items: end;
+  column-gap: 8px;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 0.8fr) max-content minmax(0, 1.6fr) max-content 100px;
+  min-height: 29px;
+  white-space: nowrap;
+}
+
+.equipment-request-meta.application-form-row > div {
+  margin: 0;
+}
+
+.equipment-request-meta-value {
+  align-items: flex-end;
+  display: flex;
+  height: 29px;
+  justify-content: center;
+  min-width: 0;
+  padding: 0 4px 2px;
+}
+
+.equipment-request-meta .employee-data {
+  font-size: 16px;
+  white-space: nowrap;
+}
+
+.equipment-request-signatures .p-3 {
+  padding-bottom: 4px !important;
+  padding-top: 4px !important;
+}
+
+.equipment-request-signatures .my-3 {
+  margin-bottom: 8px !important;
+  margin-top: 8px !important;
+}
+
 .col-no-center {
     text-align: center;
     width: 72px;
@@ -948,14 +985,19 @@ ul.dashed>li:before {
 .power-of-attorney-footer {
   align-items: flex-end;
   display: flex;
-  justify-content: space-between;
-  margin-top: 150px;
+  justify-content: flex-end;
+  margin-top: 80px;
+  padding-bottom: 70px;
 }
 
 .power-of-attorney-attachments {
+  bottom: 12mm;
   font-size: 14px;
   line-height: 1.8;
-  padding-bottom: 12px;
+  padding: 0;
+  position: absolute;
+  right: 15mm;
+  text-align: left;
   width: 48%;
 }
 

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
@@ -17,7 +17,7 @@ describe('EmployeeAplicationFormComponent', () => {
     empNo: 1234,
     company: { name: 'GSAFE' },
     userPosition: { nameTH: 'พนักงานรักษาความปลอดภัย' },
-    site: { name: 'สำนักงานใหญ่' },
+    site: { name: 'นิติบุคคลหมู่บ้านจัดสรร บ้านกลางเมือง ศรีนครินทร์-อ่อนนุช' },
     idCardNumber: '1909800608435',
     title: 'นาย',
     firstName: 'กิตติธร',
@@ -62,7 +62,46 @@ describe('EmployeeAplicationFormComponent', () => {
     fixture = TestBed.createComponent(EmployeeAplicationFormComponent);
     component = fixture.componentInstance;
     component.currentDate = new Date(2026, 6, 26);
+    fixture.nativeElement.style.display = 'block';
+    fixture.nativeElement.style.width = '1068px';
     fixture.detectChanges();
+  });
+
+  it('keeps the purchase request name, site, and date on one line', () => {
+    const pages: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('.container-fluid'));
+    const page = pages.find(candidate => candidate.textContent.includes('ใบขอซื้ออุปกรณ์'));
+
+    expect(page).toBeDefined();
+    if (!page) {
+      return;
+    }
+
+    const metadata: HTMLElement = page.querySelector('.application-form-row');
+    const values: HTMLElement[] = Array.from(metadata.querySelectorAll('.employee-data'));
+
+    expect(values.length).toBe(3);
+    expect(metadata.getBoundingClientRect().height).toBeLessThanOrEqual(32);
+    expect(Math.abs(values[0].getBoundingClientRect().top - values[1].getBoundingClientRect().top)).toBeLessThan(1);
+    expect(Math.abs(values[1].getBoundingClientRect().top - values[2].getBoundingClientRect().top)).toBeLessThan(1);
+    expect(getComputedStyle(values[1]).whiteSpace).toBe('nowrap');
+  });
+
+  it('anchors the power-of-attorney attachment note at the bottom-right page margin', () => {
+    const page: HTMLElement = fixture.nativeElement.querySelector('[data-testid="power-of-attorney-page"]');
+    const attachments: HTMLElement = page.querySelector('.power-of-attorney-attachments');
+    const signatures: HTMLElement = page.querySelector('.power-of-attorney-signatures');
+    const pageBounds = page.getBoundingClientRect();
+    const attachmentBounds = attachments.getBoundingClientRect();
+    const signatureBounds = signatures.getBoundingClientRect();
+    const rightOffset = pageBounds.right - attachmentBounds.right;
+    const bottomOffset = pageBounds.bottom - attachmentBounds.bottom;
+
+    expect(getComputedStyle(attachments).position).toBe('absolute');
+    expect(rightOffset).toBeGreaterThanOrEqual(55);
+    expect(rightOffset).toBeLessThanOrEqual(58);
+    expect(bottomOffset).toBeGreaterThanOrEqual(44);
+    expect(bottomOffset).toBeLessThanOrEqual(47);
+    expect(attachmentBounds.top - signatureBounds.bottom).toBeGreaterThanOrEqual(10);
   });
 
   it('renders a final power-of-attorney page with employee and representative details', () => {


### PR DESCRIPTION
## Summary

- keep employee name, long site name, and date on one line on the equipment purchase form
- reclaim page-scoped signature spacing so the form and form code remain on page 29
- place the power-of-attorney attachment note at the bottom-right margin without overlapping the witness signature

## Testing

- [x] Focused Karma specs: 9 passed
- [x] Targeted TSLint for the changed component spec
- [x] Production Angular build with Intel Node 12
- [x] Electron PDF visual verification: 31 pages; page 29 is complete, page 30 starts the next form, and the page 31 note is bottom-right with no overlap
- [ ] Full Karma suite: 28 pre-existing spec setup failures and 10 passes (failure count unchanged from `master`)

## Risk / Rollback

- Print layout remains sensitive to Electron renderer and font metrics; it was verified with the repository's Electron 5 and Intel Node 12 runtime.
- Roll back by reverting this PR.
