### PR TITLE
fix(report): move power-of-attorney note bottom-left

### DIFF
--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
@@ -996,7 +996,7 @@ ul.dashed>li:before {
   line-height: 1.8;
   padding: 0;
   position: absolute;
-  right: 15mm;
+  left: 15mm;
   text-align: left;
   width: 48%;
 }

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
@@ -86,19 +86,19 @@ describe('EmployeeAplicationFormComponent', () => {
     expect(getComputedStyle(values[1]).whiteSpace).toBe('nowrap');
   });
 
-  it('anchors the power-of-attorney attachment note at the bottom-right page margin', () => {
+  it('anchors the power-of-attorney attachment note at the bottom-left page margin', () => {
     const page: HTMLElement = fixture.nativeElement.querySelector('[data-testid="power-of-attorney-page"]');
     const attachments: HTMLElement = page.querySelector('.power-of-attorney-attachments');
     const signatures: HTMLElement = page.querySelector('.power-of-attorney-signatures');
     const pageBounds = page.getBoundingClientRect();
     const attachmentBounds = attachments.getBoundingClientRect();
     const signatureBounds = signatures.getBoundingClientRect();
-    const rightOffset = pageBounds.right - attachmentBounds.right;
+    const leftOffset = attachmentBounds.left - pageBounds.left;
     const bottomOffset = pageBounds.bottom - attachmentBounds.bottom;
 
     expect(getComputedStyle(attachments).position).toBe('absolute');
-    expect(rightOffset).toBeGreaterThanOrEqual(55);
-    expect(rightOffset).toBeLessThanOrEqual(58);
+    expect(leftOffset).toBeGreaterThanOrEqual(55);
+    expect(leftOffset).toBeLessThanOrEqual(58);
     expect(bottomOffset).toBeGreaterThanOrEqual(44);
     expect(bottomOffset).toBeLessThanOrEqual(47);
     expect(attachmentBounds.top - signatureBounds.bottom).toBeGreaterThanOrEqual(10);


### PR DESCRIPTION
## Summary

- move the power-of-attorney attachment note to the bottom-left A4 margin
- preserve the 12 mm bottom offset and keep the note clear of the witness signature
- update the rendered-geometry regression test to protect the corrected placement

## Testing

- [x] Focused Karma specs: 9 passed
- [x] Regression mutation check: the old right anchor fails the expected left-offset assertion
- [x] Targeted TSLint for the changed spec
- [x] Production Angular build using Intel Node.js 12
- [x] Electron PDF: 31 pages; pages 29–31 visually verified; page 31 note is bottom-left without overlap or clipping
- [ ] Full Karma suite: 28 pre-existing setup failures and 10 passes, unchanged from `master`

## Risk / Rollback

- Risk: print layout depends on Electron and font metrics; verified with the repository's Electron 5 runtime and Intel Node.js 12.
- Rollback: revert this PR.
