### PR TITLE
chore(release): 2.33.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cong-app",
-  "version": "2.32.8",
+  "version": "2.33.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cong-app",
-      "version": "2.32.8",
+      "version": "2.33.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^0.803.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cong-app",
   "productName": "Cong Application",
   "description": "Cong Application",
-  "version": "2.32.8",
+  "version": "2.33.0",
   "license": "MIT",
   "author": {
     "name": "Ubakong",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -14,6 +14,6 @@ export const environment = {
   companyWebsite: 'www.gmsecurity.co.th',
   companyTax: '0195556001137',
   appVersion: require('../../package.json').version,
-  releaseDate: '15/07/2026',
+  releaseDate: '26/07/2026',
   storageBucketUrl: 'https://storage.googleapis.com/cong-app.appspot.com'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,6 +14,6 @@ export const environment = {
   companyWebsite: 'www.gmsecurity.co.th',
   companyTax: '0195556001137',
   appVersion: require('../../package.json').version,
-  releaseDate: '15/07/2026',
+  releaseDate: '26/07/2026',
   storageBucketUrl: 'https://storage.googleapis.com/cong-app.appspot.com'
 };


### PR DESCRIPTION
## Summary

- bump the desktop application version from `2.32.8` to `2.33.0`
- set the development and production release date to `26/07/2026`

## Testing

- [x] targeted TSLint check for both changed environment files
- [x] production Electron Angular build under Node `12.22.12` x64
- [ ] full Karma suite: existing baseline is 28 failed and 10 passed because legacy component specs omit required TestBed modules and providers
- [ ] full TSLint suite: existing baseline contains errors across unchanged application files

## Risk / Rollback

- Risk is limited to release metadata; generated `dist/` and installer artifacts are not committed.
- Roll back by reverting this release commit and retaining the previous `v2.32.8` release.
