### PR TITLE
fix(report): align employee application page spacing

### DIFF
--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
@@ -3451,7 +3451,7 @@
         </div>
     </div>
 </div>
-<div class="container-fluid page-break pdpa-saraburi-page">
+<div class="container-fluid page-break pdpa-saraburi-page" data-testid="employee-application-page-23">
     <div class="pdpa-saraburi-title">
         หนังสือยินยอมในการเข้าตรวจดูข้อมูลข่าวสารส่วนบุคคล
     </div>
@@ -3598,7 +3598,7 @@
 <!-- หน้าว่าง -->
 <div class="container-fluid page-break">
 </div>
-<div class="container-fluid page-break">
+<div class="container-fluid page-break" data-testid="employee-application-page-25">
     <div class="d-flex report-top">
         <div>
             <img [src]="baseImagePath + '/img/logo-header.png'" alt="Logo" class="logo-header">

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
@@ -537,7 +537,6 @@ ul.dashed>li:before {
     display: flex;
     flex-direction: column;
     min-height: 297mm;
-    padding: 16mm 15mm 12mm;
     width: 210mm;
 }
 
@@ -870,7 +869,6 @@ ul.dashed>li:before {
   display: flex;
   flex-direction: column;
   min-height: 297mm;
-  padding: 16mm 15mm 12mm;
   width: 210mm;
 }
 
@@ -991,12 +989,12 @@ ul.dashed>li:before {
 }
 
 .power-of-attorney-attachments {
-  bottom: 12mm;
+  bottom: 25px;
   font-size: 14px;
   line-height: 1.8;
   padding: 0;
   position: absolute;
-  left: 15mm;
+  left: 50px;
   text-align: left;
   width: 48%;
 }

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
@@ -86,21 +86,46 @@ describe('EmployeeAplicationFormComponent', () => {
     expect(getComputedStyle(values[1]).whiteSpace).toBe('nowrap');
   });
 
+  it('uses the page 25 padding on pages 23 and 31', () => {
+    const page23: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-23"]');
+    const page25: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-25"]');
+    const page31: HTMLElement = fixture.nativeElement.querySelector('[data-testid="power-of-attorney-page"]');
+
+    const page25Style = getComputedStyle(page25);
+    const expectedPadding = [
+      page25Style.paddingTop,
+      page25Style.paddingRight,
+      page25Style.paddingBottom,
+      page25Style.paddingLeft
+    ];
+
+    [page23, page31].forEach(page => {
+      const style = getComputedStyle(page);
+
+      expect([
+        style.paddingTop,
+        style.paddingRight,
+        style.paddingBottom,
+        style.paddingLeft
+      ]).toEqual(expectedPadding);
+    });
+  });
+
   it('anchors the power-of-attorney attachment note at the bottom-left page margin', () => {
     const page: HTMLElement = fixture.nativeElement.querySelector('[data-testid="power-of-attorney-page"]');
+    const referencePage: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-25"]');
     const attachments: HTMLElement = page.querySelector('.power-of-attorney-attachments');
     const signatures: HTMLElement = page.querySelector('.power-of-attorney-signatures');
     const pageBounds = page.getBoundingClientRect();
     const attachmentBounds = attachments.getBoundingClientRect();
     const signatureBounds = signatures.getBoundingClientRect();
+    const referenceStyle = getComputedStyle(referencePage);
     const leftOffset = attachmentBounds.left - pageBounds.left;
     const bottomOffset = pageBounds.bottom - attachmentBounds.bottom;
 
     expect(getComputedStyle(attachments).position).toBe('absolute');
-    expect(leftOffset).toBeGreaterThanOrEqual(55);
-    expect(leftOffset).toBeLessThanOrEqual(58);
-    expect(bottomOffset).toBeGreaterThanOrEqual(44);
-    expect(bottomOffset).toBeLessThanOrEqual(47);
+    expect(Math.abs(leftOffset - parseFloat(referenceStyle.paddingLeft))).toBeLessThan(1);
+    expect(Math.abs(bottomOffset - parseFloat(referenceStyle.paddingBottom))).toBeLessThan(1);
     expect(attachmentBounds.top - signatureBounds.bottom).toBeGreaterThanOrEqual(10);
   });
 


### PR DESCRIPTION
## Summary

- Align employee application pages 23 and 31 with the shared page padding used by page 25.
- Keep the page 31 attachment note aligned to the same left and bottom content margins.
- Add computed-style regressions for page padding and attachment positioning.

## Testing

- [x] Focused Karma suite: 4 tests passed.
- [x] Production Angular build: `ng build --prod`.
- [x] Changed spec lint: `tslint -c tslint.json ...employee-aplication-form.component.spec.ts`.
- [x] `git diff --check`.
- [ ] Full Karma suite: 28 pre-existing failures on both this branch and unchanged `master` (this branch has 11 passing tests versus 10 on `master`).
- [ ] Full repository lint: existing lint violations reproduce on unchanged `master`; the changed spec passes lint independently.
- [ ] Manual Electron/PDF review was not run from the isolated worktree because `cong-app-legacy` targets the primary checkout.

## Risk / Rollback

- Risk is limited to print layout on employee application form pages 23 and 31.
- Roll back by reverting this PR.
