### PR TITLE
fix(report): update equipment request form

### DIFF
--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.html
@@ -3892,7 +3892,7 @@
 <!-- หน้าว่าง -->
 <div class="container-fluid page-break">
 </div>
-<div class="container-fluid page-break">
+<div class="container-fluid page-break" data-testid="equipment-request-page">
     <div class="d-flex report-top">
         <div>
             <img [src]="baseImagePath + '/img/logo-header.png'" alt="Logo" class="logo-header">
@@ -3911,11 +3911,13 @@
         </div>
     </div>
     <hr>
-    <div class="mt-3">
-        <div class="d-flex justify-content-center">
-            <div>
-                <span class="attachment-subtitle">ใบขอซื้ออุปกรณ์</span>
-            </div>
+    <div class="equipment-request-heading mt-3">
+        <span class="attachment-subtitle equipment-request-title">ใบขอซื้ออุปกรณ์</span>
+        <div class="equipment-request-employee-no" data-testid="equipment-request-emp-no">
+            <span>รหัสพนักงาน</span>
+            <span class="blank-dotted-bottom equipment-request-employee-no-value ml-2">
+                <span class="employee-data">{{ user?.empNo }}</span>
+            </span>
         </div>
     </div>
     <div class="equipment-request-meta application-form-row mt-2 text-input-18">
@@ -3948,11 +3950,15 @@
         <tbody>
             <tr *ngFor="let eq of equipments">
                 <td class="col-no-center">{{eq.sort_no_left}}</td>
-                <td class="col-description">{{eq.description_left}}</td>
+                <td class="col-description">
+                    <span class="equipment-description">{{eq.description_left}}</span>
+                </td>
                 <td class="col-number-right">{{eq.qty_left}}</td>
                 <td class="col-number-right">{{eq.price_left|number:'1.2-2'}}</td>
                 <td class="col-no-center">{{eq.sort_no_right}}</td>
-                <td class="col-description">{{eq.description_right}}</td>
+                <td class="col-description">
+                    <span class="equipment-description">{{eq.description_right}}</span>
+                </td>
                 <td class="col-number-right">{{eq.qty_right}}</td>
                 <td class="col-number-right" *ngIf="eq.price_right > 0; else emptyCol">{{eq.price_right|number:'1.2-2'}}</td>
                 <ng-template #emptyCol><td class="col-number-right">&nbsp;</td></ng-template>

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
@@ -716,6 +716,32 @@ ul.dashed>li:before {
     font-size: 16px;
 }
 
+.equipment-request-heading {
+  align-items: flex-end;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+}
+
+.equipment-request-title {
+  grid-column: 2;
+  justify-self: center;
+}
+
+.equipment-request-employee-no {
+  align-items: flex-end;
+  display: flex;
+  grid-column: 3;
+  justify-self: end;
+  white-space: nowrap;
+}
+
+.equipment-request-employee-no-value {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 120px;
+  padding-bottom: 2px;
+}
+
 .equipment-request-meta {
   align-items: end;
   column-gap: 8px;
@@ -760,6 +786,13 @@ ul.dashed>li:before {
 
 .col-description {
     width: 280px;
+}
+
+.equipment-description {
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100%;
 }
 
 .col-number-right {

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
@@ -86,6 +86,116 @@ describe('EmployeeAplicationFormComponent', () => {
     expect(getComputedStyle(values[1]).whiteSpace).toBe('nowrap');
   });
 
+  it('renders the 50 equipment items and prices from the reference form', () => {
+    const pages: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('.container-fluid'));
+    const page = pages.find(candidate => candidate.textContent.includes('ใบขอซื้ออุปกรณ์'));
+
+    expect(page).toBeDefined();
+    if (!page) {
+      return;
+    }
+
+    const itemRows: HTMLTableRowElement[] =
+      Array.from(page.querySelectorAll<HTMLTableRowElement>('.equipment-table tbody > tr')).slice(0, 25);
+    const actualRows = itemRows.map(row =>
+      Array.from(row.querySelectorAll('td')).map(cell => cell.textContent.trim())
+    );
+    const expectedRows = [
+      ['1', 'เสื้อยืดคอกลม สีดำ  ไซส์ ................................', '', '130.00',
+        '26', 'หมวกแก็ปครูฝึก', '', '200.00'],
+      ['2', 'เสื้อยืดคอกลม สีขาว  ไซส์ ..............................', '', '130.00',
+        '27', 'หมวกหม้อตาล ขาว ไซส์........................', '', '420.00'],
+      ['3', 'เสื้อเชิ้ตแขนสั้น ไซส์ .......................................', '', '520.00',
+        '28', 'หมวกหม้อตาล กรม ไซส์........................', '', '420.00'],
+      ['4', 'เสื้อสูท HP / BOT ไซส์ ...................................', '', '800.00',
+        '29', 'หมวกหม้อตาลมีช่อ ขาว ไซส์................', '', '500.00'],
+      ['5', 'เสื้อโปโล สีเทาไซส์ .........................................', '', '400.00',
+        '30', 'หมวกหม้อตาลมีช่อ กรม ไซส์................', '', '500.00'],
+      ['6', 'เสื้อโปโล สีกรม ไซส์ ......................................', '', '400.00',
+        '31', 'เสื้อเชิ้ตแขนยาว แสนสิริ ไซส์ ...............', '', '600.00'],
+      ['7', 'เสื้อซาฟารี ไซส์ ................................................', '', '550.00',
+        '32', 'กางเกงสีกรม แสนสิริ ไซส์ ....................', '', '1,000.00'],
+      ['8', 'เสื้อราชปะแตน สีขาว ไซส์ .............................', '', '680.00',
+        '33', 'เสื้อจราจร สีดำ', '', '300.00'],
+      ['9', 'เสื้อราชปะแตนมีอินธนู สีขาว ไซส์ ......................................', '', '680.00',
+        '34', 'เสื้อจราจร สีส้ม', '', '480.00'],
+      ['10', 'กางเกงราชปะแตน สีขาว ไซส์ .......................', '', '380.00',
+        '35', 'เสื้อกันฝนแบบแยกส่วน', '', '500.00'],
+      ['11', 'เสื้อราชปะแตน สีกรม ไซส์ .............................', '', '680.00',
+        '36', 'กระบองไฟ แบบชาร์จ', '', '300.00'],
+      ['12', 'กางเกงราชปะแตน สีกรม ไซส์ .......................', '', '380.00',
+        '37', 'ไฟฉายสปอร์ตไลท์', '', '350.00'],
+      ['13', 'กางเกงขายาว สีดำ ไซส์ ..................................', '', '380.00',
+        '38', 'วิทยุ Zignal', '', '1,700.00'],
+      ['14', 'กางเกงกระเป๋าข้าง สีดำ ไซส์ .........................', '', '500.00',
+        '39', 'วิทยุ Italk', '', '2,000.00'],
+      ['15', 'เสื้อการ์ด', '', '550.00', '40', 'แบตเตอรี่', '', '850.00'],
+      ['16', 'เข็มขัดหนัง', '', '180.00', '41', 'แท่นชาร์จ', '', '550.00'],
+      ['17', 'เนคไท', '', '200.00', '42', 'ป้ายชื่อ', '', '200.00'],
+      ['18', 'อินธนู', '', '165.00', '43', 'ป้าย Security', '', '200.00'],
+      ['19', 'นกหวีดพร้อมสาย', '', '65.00', '44', 'ป้าย Supervisor', '', '200.00'],
+      ['20', 'อาร์มคู่ล่ะ(โลโก้)', '', '70.00', '45', 'บัตรพนักงาน', '', '200.00'],
+      ['21', 'รองเท้าจังเกิ้ล ไซส์...........................................', '', '700.00',
+        '46', 'เข็มกลัดใบอนุญาต', '', '200.00'],
+      ['22', 'รองเท้าบูท', '', '200.00', '47', 'ชุดตรวจสารเสพติด', '', ''],
+      ['23', 'รองเท้าเซฟตี้ ไซส์...........................................', '', '700.00', '48', '', '', ''],
+      ['24', 'รองเท้าหนัง ไซส์..............................................', '', '700.00', '49', '', '', ''],
+      ['25', 'หมวกแก็ป Security', '', '200.00', '50', '', '', '']
+    ];
+
+    expect(page.querySelectorAll('.equipment-table tbody > tr').length).toBe(26);
+    expect(actualRows).toEqual(expectedRows);
+  });
+
+  it('keeps all equipment descriptions on one line', () => {
+    const page: HTMLElement = fixture.nativeElement.querySelector('[data-testid="equipment-request-page"]');
+    const descriptions: HTMLElement[] =
+      Array.from(page.querySelectorAll<HTMLElement>('.equipment-description'));
+
+    expect(descriptions.length).toBe(50);
+    descriptions.forEach(description => {
+      const range = document.createRange();
+      range.selectNodeContents(description);
+      const lineBoxes = Array.from(range.getClientRects()).filter(rect => rect.width > 0 && rect.height > 0);
+
+      expect(lineBoxes.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('renders the numeric employee number beside the centered equipment request title', () => {
+    const pages: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll('.container-fluid'));
+    const page = pages.find(candidate => candidate.textContent.includes('ใบขอซื้ออุปกรณ์'));
+
+    expect(page).toBeDefined();
+    if (!page) {
+      return;
+    }
+
+    const heading: HTMLElement = page.querySelector('.equipment-request-heading');
+    const employeeNo: HTMLElement = page.querySelector('[data-testid="equipment-request-emp-no"]');
+
+    expect(heading).not.toBeNull();
+    expect(employeeNo).not.toBeNull();
+    if (!heading || !employeeNo) {
+      return;
+    }
+
+    const title: HTMLElement = heading.querySelector('.attachment-subtitle');
+    const pageBounds = page.getBoundingClientRect();
+    const titleBounds = title.getBoundingClientRect();
+    const employeeNoBounds = employeeNo.getBoundingClientRect();
+    const titleCenter = titleBounds.left + titleBounds.width / 2;
+    const pageCenter = pageBounds.left + pageBounds.width / 2;
+    const employeeNoValue: HTMLElement = employeeNo.querySelector('.employee-data');
+
+    expect(employeeNo.firstElementChild.textContent.trim()).toBe('รหัสพนักงาน');
+    expect(employeeNoValue.textContent.trim()).toBe('1234');
+    expect(employeeNo.textContent).not.toContain('GSAFE');
+    expect(Math.abs(titleCenter - pageCenter)).toBeLessThan(1);
+    expect(Math.abs(titleBounds.bottom - employeeNoBounds.bottom)).toBeLessThan(1);
+    expect(employeeNoBounds.left - titleBounds.right).toBeGreaterThanOrEqual(16);
+  });
+
   it('uses the page 25 padding on pages 23 and 31', () => {
     const page23: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-23"]');
     const page25: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-25"]');

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.ts
@@ -38,32 +38,131 @@ export class EmployeeAplicationFormComponent implements OnDestroy, OnInit {
     'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'];
 
   equipments = [
-    {sort_no_left: 1, description_left: 'เสื้อยืดคอกลม สีดำ ไซส์..................', qty_left: null, price_left: 130, sort_no_right: 27, description_right: 'หมวกหม้อตาล ขาว ไซส์..................', qty_right: null, price_right: 420},
-    {sort_no_left: 2, description_left: 'เสื้อยืดคอกลม สีขาว ไซส์..................', qty_left: null, price_left: 130, sort_no_right: 28, description_right: 'หมวกหม้อตาล กรม ไซส์..................', qty_right: null, price_right: 420},
-    {sort_no_left: 3, description_left: 'เสื้อเชิ้ตแขนสั้น ไซส์..................', qty_left: null, price_left: 520, sort_no_right: 29, description_right: 'หมวกหม้อตาลมีช่อ ขาว ไซส์..................', qty_right: null, price_right: 500},
-    {sort_no_left: 4, description_left: 'เสื้อสูท HP / BOT ไซส์..................', qty_left: null, price_left: 800, sort_no_right: 30, description_right: 'หมวกหม้อตาลมีช่อ กรม ไซส์..................', qty_right: null, price_right: 500},
-    {sort_no_left: 5, description_left: 'เสื้อโปโล สีเทา ไซส์​..................', qty_left: null, price_left: 400, sort_no_right: 31, description_right: 'เสื้อเชิ้ตแขนยาว แสนสิริ ไซส์..................', qty_right: null, price_right: 300},
-    {sort_no_left: 6, description_left: 'เสื้อโปโล สีกรม ไซส์​..................', qty_left: null, price_left: 400, sort_no_right: 32, description_right: 'กางเกงสีกรม แสนสิริ ไซส์..................', qty_right: null, price_right: 1000},
-    {sort_no_left: 7, description_left: 'เสื้อซาฟารี ไซส์..................', qty_left: null, price_left: 550, sort_no_right: 33, description_right: 'เสื้อจราจร สีดำ AP', qty_right: null, price_right: 300},
-    {sort_no_left: 8, description_left: 'เสื้อราชปะแตน สีขาว ไซส์..................', qty_left: null, price_left: 680, sort_no_right: 34, description_right: 'เสื้อจราจร สีดำ GSAFE', qty_right: null, price_right: 300},
-    {sort_no_left: 9, description_left: 'เสื้อราชปะแตนมีอินธนู สีขาว ไซส์..........', qty_left: null, price_left: 680, sort_no_right: 35, description_right: 'เสื้อจราจร สีส้ม สกรีน GSF', qty_right: null, price_right: 480},
-    {sort_no_left: 10, description_left: 'กางเกงราชปะแตน สีขาว ไซส์................', qty_left: null, price_left: 380, sort_no_right: 36, description_right: 'เสื้อกันฝนแบบแยกส่วน', qty_right: null, price_right: 500},
-    {sort_no_left: 11, description_left: 'เสื้อราชปะแตน สีกรม ไซส์..................', qty_left: null, price_left: 680, sort_no_right: 37, description_right: 'กระบองไฟ แบบชาร์จ', qty_right: null, price_right: 300},
-    {sort_no_left: 12, description_left: 'กางเกงราชปะแตน สีกรม ไซส์..........', qty_left: null, price_left: 380, sort_no_right: 38, description_right: 'ไฟฉายสปอร์ตไลท์', qty_right: null, price_right: 350},
-    {sort_no_left: 13, description_left: 'กางเกงขายาวสีดำ ไซส์..................', qty_left: null, price_left: 380, sort_no_right: 39, description_right: 'วิทยุ Zignal', qty_right: null, price_right: 1700},
-    {sort_no_left: 14, description_left: 'กางเกงประเป๋าข้าง ไซส์..................', qty_left: null, price_left: 500, sort_no_right: 40, description_right: 'วิทยุ Italk', qty_right: null, price_right: 2000},
-    {sort_no_left: 15, description_left: 'เสื้อการ์ด', qty_left: null, price_left: 550, sort_no_right: 41, description_right: 'แบตเตอรี่', qty_right: null, price_right: 850},
-    {sort_no_left: 16, description_left: 'เข็มขัดหนัง', qty_left: null, price_left: 180, sort_no_right: 42, description_right: 'แท่นชาร์จ', qty_right: null, price_right: 550},
-    {sort_no_left: 17, description_left: 'เนคไท', qty_left: null, price_left: 200, sort_no_right: 43, description_right: 'ป้ายชื่อ', qty_right: null, price_right: 200},
-    {sort_no_left: 18, description_left: 'อินธนู', qty_left: null, price_left: 165, sort_no_right: 44, description_right: 'ป้าย Security', qty_right: null, price_right: 200},
-    {sort_no_left: 19, description_left: 'นกหวีดพร้อมสาย', qty_left: null, price_left: 65, sort_no_right: 45, description_right: 'ป้าย Supervisor', qty_right: null, price_right: 200},
-    {sort_no_left: 20, description_left: 'อาร์มคู่ละ(โลโก้)', qty_left: null, price_left: 70, sort_no_right: 46, description_right: 'บัตรพนักงาน', qty_right: null, price_right: 200},
-    {sort_no_left: 21, description_left: 'รองเท้าจังเกิ้ล ไซส์..................', qty_left: null, price_left: 700, sort_no_right: 47, description_right: 'เข็มกลัดใบอนุญาต', qty_right: null, price_right: 200},
-    {sort_no_left: 22, description_left: 'รองเท้าบูท', qty_left: null, price_left: 200, sort_no_right: 48, description_right: 'ชุดตรวจสารเสพติด', qty_right: null, price_right: 0},
-    {sort_no_left: 23, description_left: 'รองเท้าเซฟตี้ ไซส์..................', qty_left: null, price_left: 700, sort_no_right: 49, description_right: '', qty_right: null, price_right: 0},
-    {sort_no_left: 24, description_left: 'รองเท้าหนัง ไซส์..................', qty_left: null, price_left: 700, sort_no_right: 50, description_right: '', qty_right: null, price_right: 0},
-    {sort_no_left: 25, description_left: 'หมวกแก็ป Security', qty_left: null, price_left: 200, sort_no_right: 51, description_right: '', qty_right: null, price_right: 0},
-    {sort_no_left: 26, description_left: 'หมวกแก็ปครูฝึก', qty_left: null, price_left: 200, sort_no_right: 52, description_right: '', qty_right: null, price_right: 0},
+    {
+      sort_no_left: 1, description_left: 'เสื้อยืดคอกลม สีดำ  ไซส์ ................................',
+      qty_left: null, price_left: 130, sort_no_right: 26, description_right: 'หมวกแก็ปครูฝึก',
+      qty_right: null, price_right: 200
+    },
+    {
+      sort_no_left: 2, description_left: 'เสื้อยืดคอกลม สีขาว  ไซส์ ..............................',
+      qty_left: null, price_left: 130, sort_no_right: 27, description_right: 'หมวกหม้อตาล ขาว ไซส์........................',
+      qty_right: null, price_right: 420
+    },
+    {
+      sort_no_left: 3, description_left: 'เสื้อเชิ้ตแขนสั้น ไซส์ .......................................',
+      qty_left: null, price_left: 520, sort_no_right: 28, description_right: 'หมวกหม้อตาล กรม ไซส์........................',
+      qty_right: null, price_right: 420
+    },
+    {
+      sort_no_left: 4, description_left: 'เสื้อสูท HP / BOT ไซส์ ...................................',
+      qty_left: null, price_left: 800, sort_no_right: 29, description_right: 'หมวกหม้อตาลมีช่อ ขาว ไซส์................',
+      qty_right: null, price_right: 500
+    },
+    {
+      sort_no_left: 5, description_left: 'เสื้อโปโล สีเทาไซส์ .........................................',
+      qty_left: null, price_left: 400, sort_no_right: 30, description_right: 'หมวกหม้อตาลมีช่อ กรม ไซส์................',
+      qty_right: null, price_right: 500
+    },
+    {
+      sort_no_left: 6, description_left: 'เสื้อโปโล สีกรม ไซส์ ......................................',
+      qty_left: null, price_left: 400, sort_no_right: 31, description_right: 'เสื้อเชิ้ตแขนยาว แสนสิริ ไซส์ ...............',
+      qty_right: null, price_right: 600
+    },
+    {
+      sort_no_left: 7, description_left: 'เสื้อซาฟารี ไซส์ ................................................',
+      qty_left: null, price_left: 550, sort_no_right: 32, description_right: 'กางเกงสีกรม แสนสิริ ไซส์ ....................',
+      qty_right: null, price_right: 1000
+    },
+    {
+      sort_no_left: 8, description_left: 'เสื้อราชปะแตน สีขาว ไซส์ .............................',
+      qty_left: null, price_left: 680, sort_no_right: 33, description_right: 'เสื้อจราจร สีดำ',
+      qty_right: null, price_right: 300
+    },
+    {
+      sort_no_left: 9, description_left: 'เสื้อราชปะแตนมีอินธนู สีขาว ไซส์ ......................................',
+      qty_left: null, price_left: 680, sort_no_right: 34, description_right: 'เสื้อจราจร สีส้ม',
+      qty_right: null, price_right: 480
+    },
+    {
+      sort_no_left: 10, description_left: 'กางเกงราชปะแตน สีขาว ไซส์ .......................',
+      qty_left: null, price_left: 380, sort_no_right: 35, description_right: 'เสื้อกันฝนแบบแยกส่วน',
+      qty_right: null, price_right: 500
+    },
+    {
+      sort_no_left: 11, description_left: 'เสื้อราชปะแตน สีกรม ไซส์ .............................',
+      qty_left: null, price_left: 680, sort_no_right: 36, description_right: 'กระบองไฟ แบบชาร์จ',
+      qty_right: null, price_right: 300
+    },
+    {
+      sort_no_left: 12, description_left: 'กางเกงราชปะแตน สีกรม ไซส์ .......................',
+      qty_left: null, price_left: 380, sort_no_right: 37, description_right: 'ไฟฉายสปอร์ตไลท์',
+      qty_right: null, price_right: 350
+    },
+    {
+      sort_no_left: 13, description_left: 'กางเกงขายาว สีดำ ไซส์ ..................................',
+      qty_left: null, price_left: 380, sort_no_right: 38, description_right: 'วิทยุ Zignal',
+      qty_right: null, price_right: 1700
+    },
+    {
+      sort_no_left: 14, description_left: 'กางเกงกระเป๋าข้าง สีดำ ไซส์ .........................',
+      qty_left: null, price_left: 500, sort_no_right: 39, description_right: 'วิทยุ Italk',
+      qty_right: null, price_right: 2000
+    },
+    {
+      sort_no_left: 15, description_left: 'เสื้อการ์ด',
+      qty_left: null, price_left: 550, sort_no_right: 40, description_right: 'แบตเตอรี่',
+      qty_right: null, price_right: 850
+    },
+    {
+      sort_no_left: 16, description_left: 'เข็มขัดหนัง',
+      qty_left: null, price_left: 180, sort_no_right: 41, description_right: 'แท่นชาร์จ',
+      qty_right: null, price_right: 550
+    },
+    {
+      sort_no_left: 17, description_left: 'เนคไท',
+      qty_left: null, price_left: 200, sort_no_right: 42, description_right: 'ป้ายชื่อ',
+      qty_right: null, price_right: 200
+    },
+    {
+      sort_no_left: 18, description_left: 'อินธนู',
+      qty_left: null, price_left: 165, sort_no_right: 43, description_right: 'ป้าย Security',
+      qty_right: null, price_right: 200
+    },
+    {
+      sort_no_left: 19, description_left: 'นกหวีดพร้อมสาย',
+      qty_left: null, price_left: 65, sort_no_right: 44, description_right: 'ป้าย Supervisor',
+      qty_right: null, price_right: 200
+    },
+    {
+      sort_no_left: 20, description_left: 'อาร์มคู่ล่ะ(โลโก้)',
+      qty_left: null, price_left: 70, sort_no_right: 45, description_right: 'บัตรพนักงาน',
+      qty_right: null, price_right: 200
+    },
+    {
+      sort_no_left: 21, description_left: 'รองเท้าจังเกิ้ล ไซส์...........................................',
+      qty_left: null, price_left: 700, sort_no_right: 46, description_right: 'เข็มกลัดใบอนุญาต',
+      qty_right: null, price_right: 200
+    },
+    {
+      sort_no_left: 22, description_left: 'รองเท้าบูท',
+      qty_left: null, price_left: 200, sort_no_right: 47, description_right: 'ชุดตรวจสารเสพติด',
+      qty_right: null, price_right: 0
+    },
+    {
+      sort_no_left: 23, description_left: 'รองเท้าเซฟตี้ ไซส์...........................................',
+      qty_left: null, price_left: 700, sort_no_right: 48, description_right: '',
+      qty_right: null, price_right: 0
+    },
+    {
+      sort_no_left: 24, description_left: 'รองเท้าหนัง ไซส์..............................................',
+      qty_left: null, price_left: 700, sort_no_right: 49, description_right: '',
+      qty_right: null, price_right: 0
+    },
+    {
+      sort_no_left: 25, description_left: 'หมวกแก็ป Security',
+      qty_left: null, price_left: 200, sort_no_right: 50, description_right: '',
+      qty_right: null, price_right: 0
+    }
   ];
 
   constructor(


### PR DESCRIPTION
## Summary
- update the employee equipment-request table to match the supplied 50-item reference form
- add the numeric employee number next to the centered equipment-request title
- preserve a single-page A4 print layout with single-line equipment descriptions

## Changes
- replace the paired equipment descriptions and prices for items 1-50
- render `user?.empNo` under `รหัสพนักงาน`
- add focused regressions for table contents, employee number, title alignment, and row wrapping

## Testing
- [x] Focused Karma suite: 7/7 passed
- [x] `npx ng build --prod`
- [x] Print-to-PDF visual verification: one A4 page with all columns, notes, and signatures visible
- [x] `git diff --check`
- [ ] Full Karma suite: existing baseline remains 28 failures / 14 successes from unrelated test-module imports and providers
- [ ] Full lint: existing repository lint backlog remains

## Risk / Rollback
- Risk: low; changes are limited to the equipment-request report data, layout, and focused tests.
- Rollback: revert this PR.
