### PR TITLE
chore(release): 2.33.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /release-builds
 /release
 
+# local release credentials
+/src/.env
+
 # dependencies
 /node_modules
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cong-app",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cong-app",
-      "version": "2.33.0",
+      "version": "2.33.1",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^0.803.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cong-app",
   "productName": "Cong Application",
   "description": "Cong Application",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "license": "MIT",
   "author": {
     "name": "Ubakong",
@@ -39,6 +39,9 @@
     "directories": {
       "output": "release/"
     },
+    "files": [
+      "!src/.env"
+    ],
     "win": {
       "target": "nsis",
       "requestedExecutionLevel": "requireAdministrator"

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -14,6 +14,6 @@ export const environment = {
   companyWebsite: 'www.gmsecurity.co.th',
   companyTax: '0195556001137',
   appVersion: require('../../package.json').version,
-  releaseDate: '26/07/2026',
+  releaseDate: '11/08/2026',
   storageBucketUrl: 'https://storage.googleapis.com/cong-app.appspot.com'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,6 +14,6 @@ export const environment = {
   companyWebsite: 'www.gmsecurity.co.th',
   companyTax: '0195556001137',
   appVersion: require('../../package.json').version,
-  releaseDate: '26/07/2026',
+  releaseDate: '11/08/2026',
   storageBucketUrl: 'https://storage.googleapis.com/cong-app.appspot.com'
 };


### PR DESCRIPTION
## Summary
- bump the application version to `2.33.1`
- set the release date to `11/08/2026` in development and production environments
- keep the local deployment token out of Git and Electron packages

## Testing
- [x] targeted TSLint for both changed environment files
- [x] `cong-app-legacy build-electron`
- [x] publish-disabled Windows installer build
- [x] verified the production bundle contains version `2.33.1` and release date `11/08/2026`
- [x] verified `src/.env` is absent from `dist/` and `app.asar`
- [x] full test result matches the existing baseline: 28 failed, 14 passed
- [x] full lint result matches the existing baseline: 491 errors and 1 warning across 23 files

## Risk / Rollback
- Risk: low; the functional change is limited to release metadata, with credential-exclusion hardening.
- Rollback: revert this PR or redeploy the previous release artifact.

Deployment will run after this PR receives the repository-required approval and is merged.
