### PR TITLE
fix(report): match employee application page widths

### DIFF
--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.scss
@@ -537,7 +537,6 @@ ul.dashed>li:before {
     display: flex;
     flex-direction: column;
     min-height: 297mm;
-    width: 210mm;
 }
 
 .pdpa-saraburi-title {
@@ -902,7 +901,6 @@ ul.dashed>li:before {
   display: flex;
   flex-direction: column;
   min-height: 297mm;
-  width: 210mm;
 }
 
 .power-of-attorney-header {

--- a/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
+++ b/src/app/modules/employee/pages/report/employee-aplication-form/employee-aplication-form.component.spec.ts
@@ -221,6 +221,21 @@ describe('EmployeeAplicationFormComponent', () => {
     });
   });
 
+  it('uses the page 25 full-width horizontal bounds on pages 23 and 31', () => {
+    const page23: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-23"]');
+    const page25: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-25"]');
+    const page31: HTMLElement = fixture.nativeElement.querySelector('[data-testid="power-of-attorney-page"]');
+    const page25Bounds = page25.getBoundingClientRect();
+
+    [page23, page31].forEach(page => {
+      const bounds = page.getBoundingClientRect();
+
+      expect(Math.abs(bounds.left - page25Bounds.left)).toBeLessThan(1);
+      expect(Math.abs(bounds.right - page25Bounds.right)).toBeLessThan(1);
+      expect(Math.abs(bounds.width - page25Bounds.width)).toBeLessThan(1);
+    });
+  });
+
   it('anchors the power-of-attorney attachment note at the bottom-left page margin', () => {
     const page: HTMLElement = fixture.nativeElement.querySelector('[data-testid="power-of-attorney-page"]');
     const referencePage: HTMLElement = fixture.nativeElement.querySelector('[data-testid="employee-application-page-25"]');


### PR DESCRIPTION
## Summary

- Follow up on #89 by removing the remaining fixed A4 widths from employee application pages 23 and 31.
- Let both pages inherit the same full-width container spacing used by pages 25 and 30.
- Add a DOM geometry regression for the left edge, right edge, and width.

## Testing

- [x] Focused legacy-runtime Karma suite: 8 tests passed.
- [x] Changed spec TSLint: passed.
- [x] `cong-app-legacy build-web`.
- [x] `cong-app-legacy build-electron`.
- [ ] Full legacy-runtime Karma suite: 28 pre-existing failures remain; successes increased from 14 on the baseline to 15 with the new regression.
- [ ] Full repository lint: existing unrelated TSLint violations remain; the changed spec passes independently.
- [ ] Fresh Electron/PDF visual review was not run because generating the employee PDF requires the application data flow.

## Risk / Rollback

- Risk is limited to horizontal print layout on employee application pages 23 and 31; vertical sizing, padding, and attachment offsets are unchanged.
- Roll back by reverting this PR.
